### PR TITLE
No-op when AMI ID changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,12 @@ resource "aws_instance" "this" {
 
   ebs_optimized = var.ebs_optimized
 
+  lifecycle {
+    ignore_changes = [
+      ami,
+    ]
+  }
+
   dynamic "capacity_reservation_specification" {
     for_each = var.capacity_reservation_specification != null ? [var.capacity_reservation_specification] : []
     content {


### PR DESCRIPTION
# What
When the AMI ID changes (for example, a new Packer image has been generated) don't try to recreate the instance. I can't think of a time we'd want to do this with the current behaviour, if we wanted to truly update the AMI we can recreate the instance entirely.

# Why
Creating new hosts and need to prevent this from happening on subsequent TF apply.

# Jira ticket
This is a public repo. Enables internal work.